### PR TITLE
Add ocamlformat for emacs setup

### DIFF
--- a/emacs/emacs.ml
+++ b/emacs/emacs.ml
@@ -225,12 +225,19 @@ let base_setup =
   (autoload 'utop-minor-mode "utop" "Minor mode for utop" t)
   (add-hook 'tuareg-mode-hook 'utop-minor-mode))
 
+(defun opam-setup-ocamlformat ()
+  (load (concat opam-share "/emacs/site-lisp/ocamlformat"))
+  (opam-setup-add-ocaml-hook
+    (lambda ()
+      (define-key tuareg-mode-map (kbd "C-c C-f") #'ocamlformat))))
+
 (defvar opam-tools
   '(("tuareg" . opam-setup-tuareg)
     ("ocp-indent" . opam-setup-ocp-indent)
     ("ocp-index" . opam-setup-ocp-index)
     ("merlin" . opam-setup-merlin)
-    ("utop" . opam-setup-utop)))
+    ("utop" . opam-setup-utop)
+    ("ocamlformat" . opam-setup-ocamlformat)))
 
 (defun opam-detect-installed-tools ()
   (let*

--- a/emacs/emacs.ml
+++ b/emacs/emacs.ml
@@ -345,9 +345,19 @@ module Merlin = struct
   let pre_remove = []
 end
 
+module Ocamlformat = struct
+  (* Handled dynamically, invalid in other switches *)
+  let name = "ocamlformat"
+  let chunks = []
+  let files = []
+  let post_install = []
+  let pre_remove = []
+end
+
 let tools = [
   (module Tuareg : ToolConfig);
   (module OcpIndent : ToolConfig);
   (module OcpIndex : ToolConfig);
   (module Merlin : ToolConfig);
+  (module Ocamlformat : ToolConfig);
 ]


### PR DESCRIPTION
Hi.

I've added some implementations to integrate `ocamlformat` into Emacs setup (#40)
I only added this to Emacs setup just because my primary editor is Emacs.
It binds `C-c C-f` to call `ocamlformat` for the current buffer.

Please review this pull request.
Thank you.