### PR TITLE
Fix #53: Switch from `opam list` to `isdirectory` to detect packages.

### DIFF
--- a/vim/vim.ml
+++ b/vim/vim.ml
@@ -149,11 +149,11 @@ endfunction
 let s:opam_configuration['merlin'] = function('OpamConfMerlin')
 
 let s:opam_packages = ["ocp-indent", "ocp-index", "merlin"]
-let s:opam_check_cmdline = ["opam list --installed --short --safe --color=never"] + s:opam_packages
-let s:opam_available_tools = split(system(join(s:opam_check_cmdline)))
+let s:opam_available_tools = []
 for tool in s:opam_packages
   " Respect package order (merlin should be after ocp-index)
-  if count(s:opam_available_tools, tool) > 0
+  if isdirectory(s:opam_share_dir . "/" . tool)
+    call add(s:opam_available_tools, tool)
     call s:opam_configuration[tool]()
   endif
 endfor


### PR DESCRIPTION
This replaces the usage of `opam list` in Vim configurations with `isdirectory`. This helps as `opam list` may take well over a second, but `isdirectory` can take milliseconds.