### PR TITLE
opam-tools-installs is not an assoc list, use member instead

### DIFF
--- a/emacs/emacs.ml
+++ b/emacs/emacs.ml
@@ -312,7 +312,7 @@ module OcpIndent = struct
       let el = share_dir / "emacs" / "site-lisp" / "ocp-indent.el" in
       Printf.sprintf {elisp|
 ;; Load ocp-indent from its original switch when not found in current switch
-(when (not (assoc "ocp-indent" opam-tools-installed))
+(when (not (member "ocp-indent" opam-tools-installed))
   (autoload 'ocp-setup-indent "%s" "Improved indentation for Tuareg mode")
   (autoload 'ocp-indent-caml-mode-setup "%s" "Improved indentation for Caml mode")
   (add-hook 'tuareg-mode-hook 'ocp-setup-indent t)


### PR DESCRIPTION
Hi, I think this is a left-over as the other tools are correctly using `member`, I'm guessing this  was an assoc list at some point.
Without this my ocp-indent-path keeps getting overwritten with a full path of the switch.